### PR TITLE
Fix broken build of performWithRetry

### DIFF
--- a/codecov-haskell.cabal
+++ b/codecov-haskell.cabal
@@ -60,7 +60,7 @@ library
     cmdargs >= 0.10,
     curl >= 1.3.8,
     hpc >= 0.6,
-    retry >= 0.5,
+    retry >= 0.7,
     safe >= 0.3,
     split
 

--- a/src/Trace/Hpc/Codecov/Curl.hs
+++ b/src/Trace/Hpc/Codecov/Curl.hs
@@ -19,6 +19,7 @@ import           Data.Aeson
 import           Data.Aeson.Types (parseMaybe)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Maybe
+import           Data.Monoid
 import           Network.Curl
 import           Trace.Hpc.Codecov.Types
 
@@ -52,8 +53,9 @@ expRetryPolicy :: RetryPolicy
 expRetryPolicy = exponentialBackoff (10 * 1000 * 1000) <> limitRetries 3
 
 performWithRetry :: IO (Maybe a) -> IO (Maybe a)
-performWithRetry = retrying expRetryPolicy isNothingM
+performWithRetry action = retrying expRetryPolicy isNothingM action'
     where isNothingM _ = return . isNothing
+          action' _ = action
 
 extractCoverage :: String -> Maybe String
 extractCoverage rBody = (++ "%") . show <$> (getField "coverage" :: Maybe Integer)


### PR DESCRIPTION
Fixes #13.

It was broken due to [retry-0.7's changing of retrying function][1].

[1]: https://github.com/Soostone/retry/commit/a2ef0f0c249e5da544bd44452802381e83483c1c